### PR TITLE
Change default CA cert file path to be a useable ssl certs bundle

### DIFF
--- a/kmip/core/config_helper.py
+++ b/kmip/core/config_helper.py
@@ -36,7 +36,7 @@ class ConfigHelper(object):
         FILE_PATH, '../demos/certs/server.crt'))
     DEFAULT_KEYFILE = os.path.normpath(os.path.join(
         FILE_PATH, '../demos/certs/server.key'))
-    DEFAULT_CA_CERTS = os.path.normpath('/etc/ssl/certs/ca-bundle.crt')
+    DEFAULT_CA_CERTS = None
     DEFAULT_SSL_VERSION = 'PROTOCOL_SSLv23'
     DEFAULT_USERNAME = None
     DEFAULT_PASSWORD = None

--- a/kmip/core/config_helper.py
+++ b/kmip/core/config_helper.py
@@ -36,8 +36,7 @@ class ConfigHelper(object):
         FILE_PATH, '../demos/certs/server.crt'))
     DEFAULT_KEYFILE = os.path.normpath(os.path.join(
         FILE_PATH, '../demos/certs/server.key'))
-    DEFAULT_CA_CERTS = os.path.normpath(os.path.join(
-        FILE_PATH, '../demos/certs/server.crt'))
+    DEFAULT_CA_CERTS = os.path.normpath('/etc/ssl/certs/ca-bundle.crt')
     DEFAULT_SSL_VERSION = 'PROTOCOL_SSLv23'
     DEFAULT_USERNAME = None
     DEFAULT_PASSWORD = None


### PR DESCRIPTION
currently the default ca_cert location (i.e. when ca_certs is not specified in the pykmip client) is set to a path used in the demo script. Changing this to the default location of the ssl cert bundle allows for an empty value of ca_certs to be useful.