### PR TITLE
Change template attribute error

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1960,6 +1960,14 @@ class KmipEngine(object):
             )
 
         if payload.template_attribute:
+            object_attributes = self._process_template_attribute(payload.template_attribute)
+            if object_attributes.get('Struct'):
+                raise exceptions.InvalidField(
+                    "Template attribute is not supported."
+                )
+
+
+        if payload.template_attribute:
             raise exceptions.InvalidField(
                 "Template attribute is not supported."
             )

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1960,8 +1960,7 @@ class KmipEngine(object):
             )
 
         if payload.template_attribute:
-            object_attributes = self._process_template_attribute(payload.template_attribute)
-            if object_attributes.get('Struct'):
+            if self._process_template_attribute(payload.template_attribute):
                 raise exceptions.InvalidField(
                     "Template attribute is not supported."
                 )

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1966,12 +1966,6 @@ class KmipEngine(object):
                     "Template attribute is not supported."
                 )
 
-
-        if payload.template_attribute:
-            raise exceptions.InvalidField(
-                "Template attribute is not supported."
-            )
-
         existing_managed_object = self._get_object_with_access_controls(
             unique_identifier,
             enums.Operation.REKEY


### PR DESCRIPTION
Changing the occurrence of a template attribute error to be from a non-empty template attribute structure rather than any non-empty template attribute.