### PR TITLE
Adding an error response message if a disabled request was given

### DIFF
--- a/examples/server.conf
+++ b/examples/server.conf
@@ -11,7 +11,7 @@ tls_cipher_suites=
     EXAMPLE_CIPHER_SUITE_1
     EXAMPLE_CIPHER_SUITE_2
     EXAMPLE_CIPHER_SUITE_3
-query_exclude_operations=
+disabled_operations=
     ENCRYPT
     DECRYPT
 logging_level=INFO

--- a/kmip/services/server/config.py
+++ b/kmip/services/server/config.py
@@ -53,7 +53,7 @@ class KmipServerConfig(object):
             'tls_cipher_suites',
             'logging_level',
             'database_path',
-            'query_exclude_operations'
+            'disabled_operations'
         ]
 
     def set_setting(self, setting, value):
@@ -97,8 +97,8 @@ class KmipServerConfig(object):
             self._set_tls_cipher_suites(value)
         elif setting == 'logging_level':
             self._set_logging_level(value)
-        elif setting == 'query_exclude_operations':
-            self._set_query_exclude_operations(value)
+        elif setting == 'disabled_operations':
+            self._set_disabled_operations(value)
         else:
             self._set_database_path(value)
 
@@ -185,9 +185,9 @@ class KmipServerConfig(object):
             self._set_logging_level(
                 parser.get('server', 'logging_level')
             )
-        if parser.has_option('server', 'query_exclude_operations'):
-            self._set_query_exclude_operations(
-                parser.get('server', 'query_exclude_operations')
+        if parser.has_option('server', 'disabled_operations'):
+            self._set_disabled_operations(
+                parser.get('server', 'disabled_operations')
             )
         if parser.has_option('server', 'database_path'):
             self._set_database_path(parser.get('server', 'database_path'))
@@ -357,9 +357,9 @@ class KmipServerConfig(object):
                 "The database path, if specified, must be a valid path to a "
                 "SQLite database file."
             )
-    def _set_query_exclude_operations(self, value):
+    def _set_disabled_operations(self, value):
         if not value:
-            self.settings['query_exclude_operations'] = None
+            self.settings['disabled_operations'] = None
             return
         if isinstance(value, six.string_types):
             value = value.split()
@@ -370,7 +370,7 @@ class KmipServerConfig(object):
                         "The query excluded operations must be a set of strings "
                         "representing existing operations that will not be allowed."
                     )
-            self.settings['query_exclude_operations'] = list(set(value))
+            self.settings['disabled_operations'] = list(set(value))
         else:
             raise exceptions.ConfigurationError(
                 "The query excluded operations must be a set of strings "

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -72,7 +72,7 @@ class KmipEngine(object):
         * Cryptographic usage mask enforcement per object type
     """
 
-    def __init__(self, policies=None, database_path=None, query_exclude_operations=None):
+    def __init__(self, policies=None, database_path=None, disabled_operations=None):
         """
         Create a KmipEngine.
 
@@ -87,7 +87,7 @@ class KmipEngine(object):
         self._logger = logging.getLogger('kmip.server.engine')
 
         self._cryptography_engine = engine.CryptographyEngine()
-        self.query_exclude_operations = query_exclude_operations
+        self.disabled_operations = disabled_operations
 
         self.database_path = 'sqlite:///{}'.format(database_path)
         if not database_path:
@@ -2954,13 +2954,13 @@ class KmipEngine(object):
                     enums.Operation.SIGNATURE_VERIFY,
                     enums.Operation.MAC
                 ])
-            if isinstance(self.query_exclude_operations, list):
-                for value in self.query_exclude_operations:
+            if isinstance(self.disabled_operations, list):
+                for value in self.disabled_operations:
                     operation_names = [member.name for member in enums.Operation]
                     if value in operation_names:
                         operations.remove(enums.Operation[value])
                     else:
-                        raise exceptions.ConfigurationError("Invalid value {} in query_exclude_operations".format(value))
+                        raise exceptions.ConfigurationError("Invalid value {} in disabled_operations".format(value))
 
         if enums.QueryFunction.QUERY_OBJECTS in queries:
             objects = list()

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1288,66 +1288,65 @@ class KmipEngine(object):
     def _process_operation(self, operation, payload):
         # TODO (peterhamilton) Alphabetize this.
         if operation.name in self.disabled_operations:
-            self._logger.info("{0} has been disabled as an operation in the server configs.".format(
+            self._logger.info("{0} has been disabled in the server configs.".format(
                     operation.name.title()
                 )
             )
             raise exceptions.IllegalOperation(
-                "{0} has been disabled as an operation in the server configs.".format(
+                "{0} has been disabled in the PyKMIP server configs.".format(
                     operation.name.title()
                 )
             )
+        if operation == enums.Operation.CREATE:
+            return self._process_create(payload)
+        elif operation == enums.Operation.CREATE_KEY_PAIR:
+            return self._process_create_key_pair(payload)
+        elif operation == enums.Operation.DELETE_ATTRIBUTE:
+            return self._process_delete_attribute(payload)
+        elif operation == enums.Operation.REGISTER:
+            return self._process_register(payload)
+        elif operation == enums.Operation.REKEY:
+            return self._process_rekey(payload)
+        elif operation == enums.Operation.DERIVE_KEY:
+            return self._process_derive_key(payload)
+        elif operation == enums.Operation.LOCATE:
+            return self._process_locate(payload)
+        elif operation == enums.Operation.GET:
+            return self._process_get(payload)
+        elif operation == enums.Operation.GET_ATTRIBUTES:
+            return self._process_get_attributes(payload)
+        elif operation == enums.Operation.GET_ATTRIBUTE_LIST:
+            return self._process_get_attribute_list(payload)
+        elif operation == enums.Operation.ACTIVATE:
+            return self._process_activate(payload)
+        elif operation == enums.Operation.REVOKE:
+            return self._process_revoke(payload)
+        elif operation == enums.Operation.DESTROY:
+            return self._process_destroy(payload)
+        elif operation == enums.Operation.QUERY:
+            return self._process_query(payload)
+        elif operation == enums.Operation.DISCOVER_VERSIONS:
+            return self._process_discover_versions(payload)
+        elif operation == enums.Operation.ENCRYPT:
+            return self._process_encrypt(payload)
+        elif operation == enums.Operation.DECRYPT:
+            return self._process_decrypt(payload)
+        elif operation == enums.Operation.SIGNATURE_VERIFY:
+            return self._process_signature_verify(payload)
+        elif operation == enums.Operation.SET_ATTRIBUTE:
+            return self._process_set_attribute(payload)
+        elif operation == enums.Operation.MODIFY_ATTRIBUTE:
+            return self._process_modify_attribute(payload)
+        elif operation == enums.Operation.MAC:
+            return self._process_mac(payload)
+        elif operation == enums.Operation.SIGN:
+            return self._process_sign(payload)
         else:
-            if operation == enums.Operation.CREATE:
-                return self._process_create(payload)
-            elif operation == enums.Operation.CREATE_KEY_PAIR:
-                return self._process_create_key_pair(payload)
-            elif operation == enums.Operation.DELETE_ATTRIBUTE:
-                return self._process_delete_attribute(payload)
-            elif operation == enums.Operation.REGISTER:
-                return self._process_register(payload)
-            elif operation == enums.Operation.REKEY:
-                return self._process_rekey(payload)
-            elif operation == enums.Operation.DERIVE_KEY:
-                return self._process_derive_key(payload)
-            elif operation == enums.Operation.LOCATE:
-                return self._process_locate(payload)
-            elif operation == enums.Operation.GET:
-                return self._process_get(payload)
-            elif operation == enums.Operation.GET_ATTRIBUTES:
-                return self._process_get_attributes(payload)
-            elif operation == enums.Operation.GET_ATTRIBUTE_LIST:
-                return self._process_get_attribute_list(payload)
-            elif operation == enums.Operation.ACTIVATE:
-                return self._process_activate(payload)
-            elif operation == enums.Operation.REVOKE:
-                return self._process_revoke(payload)
-            elif operation == enums.Operation.DESTROY:
-                return self._process_destroy(payload)
-            elif operation == enums.Operation.QUERY:
-                return self._process_query(payload)
-            elif operation == enums.Operation.DISCOVER_VERSIONS:
-                return self._process_discover_versions(payload)
-            elif operation == enums.Operation.ENCRYPT:
-                return self._process_encrypt(payload)
-            elif operation == enums.Operation.DECRYPT:
-                return self._process_decrypt(payload)
-            elif operation == enums.Operation.SIGNATURE_VERIFY:
-                return self._process_signature_verify(payload)
-            elif operation == enums.Operation.SET_ATTRIBUTE:
-                return self._process_set_attribute(payload)
-            elif operation == enums.Operation.MODIFY_ATTRIBUTE:
-                return self._process_modify_attribute(payload)
-            elif operation == enums.Operation.MAC:
-                return self._process_mac(payload)
-            elif operation == enums.Operation.SIGN:
-                return self._process_sign(payload)
-            else:
-                raise exceptions.OperationNotSupported(
-                    "{0} operation is not supported by the server.".format(
-                        operation.name.title()
-                    )
+            raise exceptions.OperationNotSupported(
+                "{0} operation is not supported by the server.".format(
+                    operation.name.title()
                 )
+            )
 
     @_kmip_version_supported('1.0')
     def _process_create(self, payload):

--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1287,56 +1287,67 @@ class KmipEngine(object):
 
     def _process_operation(self, operation, payload):
         # TODO (peterhamilton) Alphabetize this.
-        if operation == enums.Operation.CREATE:
-            return self._process_create(payload)
-        elif operation == enums.Operation.CREATE_KEY_PAIR:
-            return self._process_create_key_pair(payload)
-        elif operation == enums.Operation.DELETE_ATTRIBUTE:
-            return self._process_delete_attribute(payload)
-        elif operation == enums.Operation.REGISTER:
-            return self._process_register(payload)
-        elif operation == enums.Operation.REKEY:
-            return self._process_rekey(payload)
-        elif operation == enums.Operation.DERIVE_KEY:
-            return self._process_derive_key(payload)
-        elif operation == enums.Operation.LOCATE:
-            return self._process_locate(payload)
-        elif operation == enums.Operation.GET:
-            return self._process_get(payload)
-        elif operation == enums.Operation.GET_ATTRIBUTES:
-            return self._process_get_attributes(payload)
-        elif operation == enums.Operation.GET_ATTRIBUTE_LIST:
-            return self._process_get_attribute_list(payload)
-        elif operation == enums.Operation.ACTIVATE:
-            return self._process_activate(payload)
-        elif operation == enums.Operation.REVOKE:
-            return self._process_revoke(payload)
-        elif operation == enums.Operation.DESTROY:
-            return self._process_destroy(payload)
-        elif operation == enums.Operation.QUERY:
-            return self._process_query(payload)
-        elif operation == enums.Operation.DISCOVER_VERSIONS:
-            return self._process_discover_versions(payload)
-        elif operation == enums.Operation.ENCRYPT:
-            return self._process_encrypt(payload)
-        elif operation == enums.Operation.DECRYPT:
-            return self._process_decrypt(payload)
-        elif operation == enums.Operation.SIGNATURE_VERIFY:
-            return self._process_signature_verify(payload)
-        elif operation == enums.Operation.SET_ATTRIBUTE:
-            return self._process_set_attribute(payload)
-        elif operation == enums.Operation.MODIFY_ATTRIBUTE:
-            return self._process_modify_attribute(payload)
-        elif operation == enums.Operation.MAC:
-            return self._process_mac(payload)
-        elif operation == enums.Operation.SIGN:
-            return self._process_sign(payload)
-        else:
-            raise exceptions.OperationNotSupported(
-                "{0} operation is not supported by the server.".format(
+        if operation.name in self.disabled_operations:
+            self._logger.info("{0} has been disabled as an operation in the server configs.".format(
                     operation.name.title()
                 )
             )
+            raise exceptions.IllegalOperation(
+                "{0} has been disabled as an operation in the server configs.".format(
+                    operation.name.title()
+                )
+            )
+        else:
+            if operation == enums.Operation.CREATE:
+                return self._process_create(payload)
+            elif operation == enums.Operation.CREATE_KEY_PAIR:
+                return self._process_create_key_pair(payload)
+            elif operation == enums.Operation.DELETE_ATTRIBUTE:
+                return self._process_delete_attribute(payload)
+            elif operation == enums.Operation.REGISTER:
+                return self._process_register(payload)
+            elif operation == enums.Operation.REKEY:
+                return self._process_rekey(payload)
+            elif operation == enums.Operation.DERIVE_KEY:
+                return self._process_derive_key(payload)
+            elif operation == enums.Operation.LOCATE:
+                return self._process_locate(payload)
+            elif operation == enums.Operation.GET:
+                return self._process_get(payload)
+            elif operation == enums.Operation.GET_ATTRIBUTES:
+                return self._process_get_attributes(payload)
+            elif operation == enums.Operation.GET_ATTRIBUTE_LIST:
+                return self._process_get_attribute_list(payload)
+            elif operation == enums.Operation.ACTIVATE:
+                return self._process_activate(payload)
+            elif operation == enums.Operation.REVOKE:
+                return self._process_revoke(payload)
+            elif operation == enums.Operation.DESTROY:
+                return self._process_destroy(payload)
+            elif operation == enums.Operation.QUERY:
+                return self._process_query(payload)
+            elif operation == enums.Operation.DISCOVER_VERSIONS:
+                return self._process_discover_versions(payload)
+            elif operation == enums.Operation.ENCRYPT:
+                return self._process_encrypt(payload)
+            elif operation == enums.Operation.DECRYPT:
+                return self._process_decrypt(payload)
+            elif operation == enums.Operation.SIGNATURE_VERIFY:
+                return self._process_signature_verify(payload)
+            elif operation == enums.Operation.SET_ATTRIBUTE:
+                return self._process_set_attribute(payload)
+            elif operation == enums.Operation.MODIFY_ATTRIBUTE:
+                return self._process_modify_attribute(payload)
+            elif operation == enums.Operation.MAC:
+                return self._process_mac(payload)
+            elif operation == enums.Operation.SIGN:
+                return self._process_sign(payload)
+            else:
+                raise exceptions.OperationNotSupported(
+                    "{0} operation is not supported by the server.".format(
+                        operation.name.title()
+                    )
+                )
 
     @_kmip_version_supported('1.0')
     def _process_create(self, payload):

--- a/kmip/services/server/server.py
+++ b/kmip/services/server/server.py
@@ -62,7 +62,7 @@ class KmipServer(object):
             logging_level=None,
             live_policies=False,
             database_path=None,
-            query_exclude_operations=None
+            disabled_operations=None
     ):
         """
         Create a KmipServer.
@@ -146,7 +146,7 @@ class KmipServer(object):
             tls_cipher_suites,
             logging_level,
             database_path,
-            query_exclude_operations
+            disabled_operations
         )
         self.live_policies = live_policies
         self.policies = {}
@@ -197,7 +197,7 @@ class KmipServer(object):
             tls_cipher_suites=None,
             logging_level=None,
             database_path=None,
-            query_exclude_operations=None
+            disabled_operations=None
     ):
         if path:
             self.config.load_settings(path)
@@ -230,10 +230,10 @@ class KmipServer(object):
             self.config.set_setting('logging_level', logging_level)
         if database_path:
             self.config.set_setting('database_path', database_path)
-        if query_exclude_operations:
+        if disabled_operations:
             self.config.set_setting(
-                'query_exclude_operations',
-                query_exclude_operations.split(',')
+                'disabled_operations',
+                disabled_operations.split(',')
             )
 
     def start(self):
@@ -270,7 +270,7 @@ class KmipServer(object):
         self._engine = engine.KmipEngine(
             policies=self.policies,
             database_path=self.config.settings.get('database_path'),
-            query_exclude_operations=self.config.settings.get('query_exclude_operations')
+            disabled_operations=self.config.settings.get('disabled_operations')
         )
 
         self._logger.info("Starting server socket handler.")


### PR DESCRIPTION
Adding an error response message if a disabled encrypt/decrypt request was given, as well as renaming query_exclude_operations to disabled_operations.

To disable an operation, simply add disabled_operations=, followed by any operations that are to be disabled