### PR TITLE
bug fix for Nonetype error of disabled_operations

### DIFF
--- a/kmip/services/server/engine.py
+++ b/kmip/services/server/engine.py
@@ -1287,7 +1287,7 @@ class KmipEngine(object):
 
     def _process_operation(self, operation, payload):
         # TODO (peterhamilton) Alphabetize this.
-        if operation.name in self.disabled_operations:
+        if self.disabled_operations and operation.name in self.disabled_operations:
             self._logger.info("{0} has been disabled in the server configs.".format(
                     operation.name.title()
                 )


### PR DESCRIPTION
When no disabled_operations are specified in conf `if operation.name in self.disabled_operations` gave a Nonetype error, so now we make sure it is not None first