### PR TITLE
Fix deprecation warnings

### DIFF
--- a/kmip/pie/sqltypes.py
+++ b/kmip/pie/sqltypes.py
@@ -84,6 +84,7 @@ class EnumType(types.TypeDecorator):
     """
 
     impl = types.Integer
+    cache_ok = False
 
     def __init__(self, cls):
         """

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -285,13 +285,14 @@ class KMIPProxy(object):
             six.reraise(*last_error)
 
     def _create_socket(self, sock):
-        self.socket = ssl.wrap_socket(
-            sock,
+        context = ssl.SSLContext(self.ssl_version)
+        context.load_cert_chain(
             keyfile=self.keyfile,
-            certfile=self.certfile,
-            cert_reqs=self.cert_reqs,
-            ssl_version=self.ssl_version,
-            ca_certs=self.ca_certs,
+            certfile=self.certfile,)
+        context.verify_mode = self.cert_reqs
+        context.load_verify_locations(cadatself.ca_certs)
+        self.socket = context.wrap_socket(
+            sock,
             do_handshake_on_connect=self.do_handshake_on_connect,
             suppress_ragged_eofs=self.suppress_ragged_eofs)
         self.socket.settimeout(self.timeout)

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -290,7 +290,7 @@ class KMIPProxy(object):
             keyfile=self.keyfile,
             certfile=self.certfile)
         context.verify_mode = self.cert_reqs
-        context.load_verify_locations(cadata=self.ca_certs)
+        context.load_verify_locations(cafile=self.ca_certs)
         self.socket = context.wrap_socket(
             sock,
             do_handshake_on_connect=self.do_handshake_on_connect,

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -288,9 +288,9 @@ class KMIPProxy(object):
         context = ssl.SSLContext(self.ssl_version)
         context.load_cert_chain(
             keyfile=self.keyfile,
-            certfile=self.certfile,)
+            certfile=self.certfile)
         context.verify_mode = self.cert_reqs
-        context.load_verify_locations(cadatself.ca_certs)
+        context.load_verify_locations(cadata=self.ca_certs)
         self.socket = context.wrap_socket(
             sock,
             do_handshake_on_connect=self.do_handshake_on_connect,

--- a/kmip/services/server/crypto/engine.py
+++ b/kmip/services/server/crypto/engine.py
@@ -18,7 +18,7 @@ import os
 
 from cryptography import exceptions as errors
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.decrepit.ciphers import new_algorithms
+from cryptography.hazmat.decrepit.ciphers import algorithms as new_algorithms
 from cryptography.hazmat.primitives import serialization, hashes, hmac, cmac
 from cryptography.hazmat.primitives import padding as symmetric_padding
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/kmip/services/server/crypto/engine.py
+++ b/kmip/services/server/crypto/engine.py
@@ -18,14 +18,14 @@ import os
 
 from cryptography import exceptions as errors
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.decrepit.ciphers import algorithms
+from cryptography.hazmat.decrepit.ciphers import new_algorithms
 from cryptography.hazmat.primitives import serialization, hashes, hmac, cmac
 from cryptography.hazmat.primitives import padding as symmetric_padding
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric import padding as \
     asymmetric_padding
 from cryptography.hazmat.primitives import ciphers, keywrap
-from cryptography.hazmat.primitives.ciphers import modes
+from cryptography.hazmat.primitives.ciphers import algorithms, modes
 from cryptography.hazmat.primitives.kdf import hkdf
 from cryptography.hazmat.primitives.kdf import kbkdf
 from cryptography.hazmat.primitives.kdf import pbkdf2
@@ -50,13 +50,13 @@ class CryptographyEngine(api.CryptographicEngine):
         # The IDEA algorithm is supported by cryptography but may not be
         # supported by certain backends, like OpenSSL.
         self._symmetric_key_algorithms = {
-            enums.CryptographicAlgorithm.TRIPLE_DES: algorithms.TripleDES,
+            enums.CryptographicAlgorithm.TRIPLE_DES: new_algorithms.TripleDES,
             enums.CryptographicAlgorithm.AES:        algorithms.AES,
-            enums.CryptographicAlgorithm.BLOWFISH:   algorithms.Blowfish,
+            enums.CryptographicAlgorithm.BLOWFISH:   new_algorithms.Blowfish,
             enums.CryptographicAlgorithm.CAMELLIA:   algorithms.Camellia,
-            enums.CryptographicAlgorithm.CAST5:      algorithms.CAST5,
-            enums.CryptographicAlgorithm.IDEA:       algorithms.IDEA,
-            enums.CryptographicAlgorithm.RC4:        algorithms.ARC4
+            enums.CryptographicAlgorithm.CAST5:      new_algorithms.CAST5,
+            enums.CryptographicAlgorithm.IDEA:       new_algorithms.IDEA,
+            enums.CryptographicAlgorithm.RC4:        new_algorithms.ARC4
         }
         self._asymmetric_key_algorithms = {
             enums.CryptographicAlgorithm.RSA: self._create_rsa_key_pair

--- a/kmip/services/server/crypto/engine.py
+++ b/kmip/services/server/crypto/engine.py
@@ -18,13 +18,14 @@ import os
 
 from cryptography import exceptions as errors
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.decrepit.ciphers import algorithms
 from cryptography.hazmat.primitives import serialization, hashes, hmac, cmac
 from cryptography.hazmat.primitives import padding as symmetric_padding
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.asymmetric import padding as \
     asymmetric_padding
 from cryptography.hazmat.primitives import ciphers, keywrap
-from cryptography.hazmat.primitives.ciphers import algorithms, modes
+from cryptography.hazmat.primitives.ciphers import modes
 from cryptography.hazmat.primitives.kdf import hkdf
 from cryptography.hazmat.primitives.kdf import kbkdf
 from cryptography.hazmat.primitives.kdf import pbkdf2


### PR DESCRIPTION
No more warnings!
```
(cloudianqa_venv) [root@cloudian-node1 cloudianqa]# TestRail/Horizontal/DependComponents/KMIP/launch_pykmip_server.py
Certificate was added to keystore
(cloudianqa_venv) [root@cloudian-node1 cloudianqa]# TestRail/Horizontal/DependComponents/KMIP/new/encrypt/test_pykmip_default_hs_55272.py
.

Ran 1 test in 7.188s

OK
```