### PR TITLE
Remove ssl_version field from client to fix more dependency warnings

### DIFF
--- a/kmip/pie/client.py
+++ b/kmip/pie/client.py
@@ -60,7 +60,6 @@ class ProxyKmipClient(object):
                  cert=None,
                  key=None,
                  ca=None,
-                 ssl_version=None,
                  username=None,
                  password=None,
                  config='client',
@@ -81,9 +80,6 @@ class ProxyKmipClient(object):
                 Optional, defaults to None.
             ca (string): The path to the CA certificate used to verify the
                 server's certificate. Optional, defaults to None.
-            ssl_version (string): The name of the ssl version to use for the
-                connection. Example: 'PROTOCOL_SSLv23'. Optional, defaults to
-                None.
             username (string): The username of the KMIP appliance account to
                 use for operations. Optional, defaults to None.
             password (string): The password of the KMIP appliance account to
@@ -112,7 +108,6 @@ class ProxyKmipClient(object):
             certfile=cert,
             keyfile=key,
             ca_certs=ca,
-            ssl_version=ssl_version,
             username=username,
             password=password,
             config=config,

--- a/kmip/services/auth.py
+++ b/kmip/services/auth.py
@@ -231,4 +231,4 @@ class TLS12AuthenticationSuite(AuthenticationSuite):
                 suites. Optional, defaults to None.
         """
         super(TLS12AuthenticationSuite, self).__init__(cipher_suites)
-        self._protocol = ssl.PROTOCOL_TLS_SERVER
+        self._protocol = ssl.PROTOCOL_TLSv1_2

--- a/kmip/services/auth.py
+++ b/kmip/services/auth.py
@@ -231,4 +231,4 @@ class TLS12AuthenticationSuite(AuthenticationSuite):
                 suites. Optional, defaults to None.
         """
         super(TLS12AuthenticationSuite, self).__init__(cipher_suites)
-        self._protocol = ssl.PROTOCOL_TLSv1_2
+        self._protocol = ssl.PROTOCOL_TLS_SERVER

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -255,8 +255,7 @@ class KMIPProxy(object):
             "KMIPProxy cert_reqs: {0} (CERT_REQUIRED: {1})".format(
                 self.cert_reqs, ssl.CERT_REQUIRED))
         self.logger.debug(
-            "KMIPProxy ssl_version: {0} (PROTOCOL_SSLv23: {1})".format(
-                self.ssl_version, ssl.PROTOCOL_SSLv23))
+            "KMIPProxy ssl_version: {0}".format(self.ssl_version))
         self.logger.debug("KMIPProxy ca_certs: {0}".format(self.ca_certs))
         self.logger.debug("KMIPProxy do_handshake_on_connect: {0}".format(
             self.do_handshake_on_connect))

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -282,16 +282,15 @@ class KMIPProxy(object):
             six.reraise(*last_error)
 
     def _create_socket(self, sock):
-        context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH,
-                                             cafile=self.ca_certs)
-        #context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        context.minimum_version = ssl.TLSVersion.TLSv1_2
-        context.maximum_version = ssl.TLSVersion.TLSv1_3
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        #context.minimum_version = ssl.TLSVersion.TLSv1_2
+        #context.maximum_version = ssl.TLSVersion.TLSv1_3
         context.load_cert_chain(
             keyfile=self.keyfile,
             certfile=self.certfile)
         context.verify_mode = self.cert_reqs
-        #context.load_verify_locations(cafile=self.ca_certs)
+        context.load_verify_locations(cafile=self.ca_certs)
+        context.check_hostname = False
         self.socket = context.wrap_socket(
             sock,
             do_handshake_on_connect=self.do_handshake_on_connect,

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -292,6 +292,7 @@ class KMIPProxy(object):
         context.load_verify_locations(cafile=self.ca_certs)
         self.socket = context.wrap_socket(
             sock,
+            server_hostname=self.host,
             do_handshake_on_connect=self.do_handshake_on_connect,
             suppress_ragged_eofs=self.suppress_ragged_eofs)
         self.socket.settimeout(self.timeout)

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -283,8 +283,6 @@ class KMIPProxy(object):
 
     def _create_socket(self, sock):
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        #context.minimum_version = ssl.TLSVersion.TLSv1_2
-        #context.maximum_version = ssl.TLSVersion.TLSv1_3
         context.load_cert_chain(
             keyfile=self.keyfile,
             certfile=self.certfile)

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -282,17 +282,18 @@ class KMIPProxy(object):
             six.reraise(*last_error)
 
     def _create_socket(self, sock):
-        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH,
+                                             cafile=self.ca_certs)
+        #context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         context.minimum_version = ssl.TLSVersion.TLSv1_2
         context.maximum_version = ssl.TLSVersion.TLSv1_3
         context.load_cert_chain(
             keyfile=self.keyfile,
             certfile=self.certfile)
         context.verify_mode = self.cert_reqs
-        context.load_verify_locations(cafile=self.ca_certs)
+        #context.load_verify_locations(cafile=self.ca_certs)
         self.socket = context.wrap_socket(
             sock,
-            server_hostname=self.host,
             do_handshake_on_connect=self.do_handshake_on_connect,
             suppress_ragged_eofs=self.suppress_ragged_eofs)
         self.socket.settimeout(self.timeout)

--- a/kmip/services/kmip_client.py
+++ b/kmip/services/kmip_client.py
@@ -77,7 +77,7 @@ class KMIPProxy(object):
 
     def __init__(self, host=None, port=None, keyfile=None,
                  certfile=None,
-                 cert_reqs=None, ssl_version=None, ca_certs=None,
+                 cert_reqs=None, ca_certs=None,
                  do_handshake_on_connect=None,
                  suppress_ragged_eofs=None,
                  username=None, password=None, timeout=30, config='client',
@@ -109,7 +109,7 @@ class KMIPProxy(object):
                 )
 
         self._set_variables(host, port, keyfile, certfile,
-                            cert_reqs, ssl_version, ca_certs,
+                            cert_reqs, ca_certs,
                             do_handshake_on_connect, suppress_ragged_eofs,
                             username, password, timeout, config_file)
         self.batch_items = []
@@ -254,8 +254,6 @@ class KMIPProxy(object):
         self.logger.debug(
             "KMIPProxy cert_reqs: {0} (CERT_REQUIRED: {1})".format(
                 self.cert_reqs, ssl.CERT_REQUIRED))
-        self.logger.debug(
-            "KMIPProxy ssl_version: {0}".format(self.ssl_version))
         self.logger.debug("KMIPProxy ca_certs: {0}".format(self.ca_certs))
         self.logger.debug("KMIPProxy do_handshake_on_connect: {0}".format(
             self.do_handshake_on_connect))
@@ -284,7 +282,9 @@ class KMIPProxy(object):
             six.reraise(*last_error)
 
     def _create_socket(self, sock):
-        context = ssl.SSLContext(self.ssl_version)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
+        context.maximum_version = ssl.TLSVersion.TLSv1_3
         context.load_cert_chain(
             keyfile=self.keyfile,
             certfile=self.certfile)
@@ -1736,7 +1736,7 @@ class KMIPProxy(object):
         return response
 
     def _set_variables(self, host, port, keyfile, certfile,
-                       cert_reqs, ssl_version, ca_certs,
+                       cert_reqs, ca_certs,
                        do_handshake_on_connect, suppress_ragged_eofs,
                        username, password, timeout, config_file):
         conf = ConfigHelper(config_file)
@@ -1760,9 +1760,6 @@ class KMIPProxy(object):
 
         self.cert_reqs = getattr(ssl, conf.get_valid_value(
             cert_reqs, self.config, 'cert_reqs', 'CERT_REQUIRED'))
-
-        self.ssl_version = getattr(ssl, conf.get_valid_value(
-            ssl_version, self.config, 'ssl_version', conf.DEFAULT_SSL_VERSION))
 
         self.ca_certs = conf.get_valid_value(
             ca_certs, self.config, 'ca_certs', conf.DEFAULT_CA_CERTS)

--- a/kmip/tests/unit/services/test_kmip_client.py
+++ b/kmip/tests/unit/services/test_kmip_client.py
@@ -709,7 +709,6 @@ class TestKMIPClient(TestCase):
             keyfile=None,
             certfile=None,
             cert_reqs=None,
-            ssl_version=None,
             ca_certs=None,
             do_handshake_on_connect=False,
             suppress_ragged_eofs=None,
@@ -729,7 +728,7 @@ class TestKMIPClient(TestCase):
         expected_error = TypeError
 
         kwargs = {'host': host, 'port': None, 'keyfile': None,
-                  'certfile': None, 'cert_reqs': None, 'ssl_version': None,
+                  'certfile': None, 'cert_reqs': None,
                   'ca_certs': None, 'do_handshake_on_connect': False,
                   'suppress_ragged_eofs': None, 'username': None,
                   'password': None, 'timeout': None}


### PR DESCRIPTION
Fixing:
`/root/cloudianqa_venv/lib/python3.10/site-packages/kmip/services/kmip_client.py:288: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
  context = ssl.SSLContext(self.ssl_version)`
  
Fix was actually rather simple as it never seemed to really be used in reality (as the `ssl_version` field was entirely optional) and it's functionality is entirely deprecated by the use of `ssl.PROTOCOL_TLS_CLIENT` which now does everything it needs to automatically.
The new context caused problems elsewhere though, but issues were avoided by forcing `check_hostname` to false, it is not necessary for the way we use certs in our testing.